### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 # Changelog
 
+## [0.2.0](https://github.com/marccarre/ssh-to-ansible/releases/tag/0.2.0) - 2023-11-11
+
+- Added the ability to read SSH configuration from either `stdin` (default) or
+  an input file.
+- Added the ability to write the Ansible YAML inventor to either `stdout`
+  (default) or an output file.
+- Improved tests.
+- Added code coverage reports as part of CI.
+
 ## [0.1.0](https://github.com/marccarre/ssh-to-ansible/releases/tag/0.1.0) - 2023-11-11
 
-### Added
-
-- Basic logic to parse SSH configuration from standard input and serialise it as
-  an Ansible YAML inventory.
-- Basic user documentation in [README.md](./README.md).
+- Added basic logic to parse SSH configuration from standard input and serialise
+  it as an Ansible YAML inventory.
+- Added basic user documentation in [README.md](./README.md).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-to-ansible"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Marc Carré <carre.marc@gmail.com>"]
 categories = ["command-line-utilities", "development-tools", "parsing"]
 description = "A tool to convert a SSH configuration to an Ansible YAML inventory."


### PR DESCRIPTION
### Changelog

- Added the ability to read SSH configuration from either `stdin` (default) or
  an input file.
- Added the ability to write the Ansible YAML inventor to either `stdout`
  (default) or an output file.
- Improved tests.
- Added code coverage reports as part of CI.