### PR TITLE
Add support for ansible_ssh_extra_args and ansible_ssh_common_args

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
-      - id: check-byte-order-marker
+      - id: fix-byte-order-marker
       - id: check-case-conflict
       - id: check-merge-conflict
       - id: check-symlinks

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ lazy_static = "1.4.0"
 log = "0.4.20"
 serde = { version = "1.0.192", features = ["derive"] }
 serde_yaml = "0.9.27"
-ssh2-config = "0.2.2"
 strum = { version = "0.25.0", features = ["derive"] }
 strum_macros = "0.25.3"
 thiserror = "1.0.50"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ lto = true
 clap = { version = "4.4.7", features = ["derive", "string"] }
 clap-verbosity-flag = "2.1.0"
 console-subscriber = "0.2.0"
+lazy_static = "1.4.0"
 log = "0.4.20"
 serde = { version = "1.0.192", features = ["derive"] }
 serde_yaml = "0.9.27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ log = "0.4.20"
 serde = { version = "1.0.192", features = ["derive"] }
 serde_yaml = "0.9.27"
 ssh2-config = "0.2.2"
+strum = { version = "0.25.0", features = ["derive"] }
+strum_macros = "0.25.3"
 thiserror = "1.0.50"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.17", features = ["json"] }

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ for the Ansible inventory, and optionally provide an output YAML file.
 By default, `s2a` defaults the environment to be `local`, reads from `stdin` and
 writes to `stdout`:
 
+<!-- markdownlint-disable MD013 -->
 ```console
 $ cat <<EOF | s2a
 Host default
@@ -52,10 +53,13 @@ local:
       ansible_port: 50022
       ansible_user: vagrant
       ansible_ssh_private_key_file: /Users/me/.vagrant/machines/default/qemu/private_key
+      ansible_ssh_extra_args: -o HostKeyAlgorithms=+ssh-rsa -o IdentitiesOnly=yes -o LogLevel=FATAL -o PasswordAuthentication=no -o PubkeyAcceptedKeyTypes=+ssh-rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
 ```
+<!-- markdownlint-enable MD013 -->
 
 #### Configure the Ansible inventory's environment
 
+<!-- markdownlint-disable MD013 -->
 ```console
 $ cat <<EOF | s2a -e dev
 Host default
@@ -79,10 +83,13 @@ dev:
       ansible_port: 50022
       ansible_user: vagrant
       ansible_ssh_private_key_file: /Users/me/.vagrant/machines/default/qemu/private_key
+      ansible_ssh_extra_args: -o HostKeyAlgorithms=+ssh-rsa -o IdentitiesOnly=yes -o LogLevel=FATAL -o PasswordAuthentication=no -o PubkeyAcceptedKeyTypes=+ssh-rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
 ```
+<!-- markdownlint-enable MD013 -->
 
 #### Read from input file instead of `stdin`
 
+<!-- markdownlint-disable MD013 -->
 ```console
 $ cat <<EOF > ssh_config
 Host default
@@ -108,10 +115,13 @@ local:
       ansible_port: 50022
       ansible_user: vagrant
       ansible_ssh_private_key_file: /Users/me/.vagrant/machines/default/qemu/private_key
+      ansible_ssh_extra_args: -o HostKeyAlgorithms=+ssh-rsa -o IdentitiesOnly=yes -o LogLevel=FATAL -o PasswordAuthentication=no -o PubkeyAcceptedKeyTypes=+ssh-rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
 ```
+<!-- markdownlint-enable MD013 -->
 
 #### Write to output file instead of `stdout`
 
+<!-- markdownlint-disable MD013 -->
 ```console
 $ cat <<EOF | s2a -o local.yaml
 Host default
@@ -136,7 +146,9 @@ local:
       ansible_port: 50022
       ansible_user: vagrant
       ansible_ssh_private_key_file: /Users/me/.vagrant/machines/default/qemu/private_key
+      ansible_ssh_extra_args: -o HostKeyAlgorithms=+ssh-rsa -o IdentitiesOnly=yes -o LogLevel=FATAL -o PasswordAuthentication=no -o PubkeyAcceptedKeyTypes=+ssh-rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
 ```
+<!-- markdownlint-enable MD013 -->
 
 ### Help
 

--- a/justfile
+++ b/justfile
@@ -17,6 +17,7 @@ lint:
 
 cover:
     mkdir -p target/coverage/html
+    CARGO_INCREMENTAL=0 RUSTFLAGS='-Cinstrument-coverage' cargo build
     CARGO_INCREMENTAL=0 RUSTFLAGS='-Cinstrument-coverage' LLVM_PROFILE_FILE='cargo-test-%p-%m.profraw' cargo test
     grcov . --binary-path ./target/debug/deps/ -s . -t html --branch --ignore-not-existing --ignore '../*' --ignore "/*" -o target/coverage/
     grcov . --binary-path ./target/debug/deps/ -s . -t lcov --branch --ignore-not-existing --ignore '../*' --ignore "/*" -o target/coverage/tests.lcov

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -5,9 +5,6 @@ pub enum AppError {
     #[error("Invalid user input for arg \"{arg}\". Reason: {reason}")]
     InvalidInput { arg: &'static str, reason: String },
 
-    #[error("Failed to parse SSH configuration: {0}")]
-    Parsing(#[from] ssh2_config::SshParserError),
-
     #[error("Failed to serialise to YAML: {0}")]
     Yaml(#[from] serde_yaml::Error),
 

--- a/src/common/testing.rs
+++ b/src/common/testing.rs
@@ -5,7 +5,7 @@ pub mod utilities {
     use std::{fs::File, io::BufReader};
     use tempfile::{tempdir, TempDir};
 
-    pub const SAMPLE_SSH_CONFIG: &str = r###"Host default
+    pub const SAMPLE_SSH_CONFIG: &str = r#"Host default
   HostName 127.0.0.1
   User vagrant
   Port 50022
@@ -16,18 +16,18 @@ pub mod utilities {
   IdentitiesOnly yes
   LogLevel FATAL
   PubkeyAcceptedKeyTypes +ssh-rsa
-  HostKeyAlgorithms +ssh-rsa"###;
+  HostKeyAlgorithms +ssh-rsa"#;
 
     pub fn sample_ansible_inventory(environment: &str) -> String {
         format!(
-            r###"{environment}:
+            r#"{environment}:
   hosts:
     default:
       ansible_host: 127.0.0.1
       ansible_port: 50022
       ansible_user: vagrant
       ansible_ssh_private_key_file: /path/to/private_key
-"###
+"#
         )
     }
 

--- a/src/common/testing.rs
+++ b/src/common/testing.rs
@@ -27,6 +27,7 @@ pub mod utilities {
       ansible_port: 50022
       ansible_user: vagrant
       ansible_ssh_private_key_file: /path/to/private_key
+      ansible_ssh_extra_args: -o HostKeyAlgorithms=+ssh-rsa -o IdentitiesOnly=yes -o LogLevel=FATAL -o PasswordAuthentication=no -o PubkeyAcceptedKeyTypes=+ssh-rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
 "#
         )
     }

--- a/src/common/testing.rs
+++ b/src/common/testing.rs
@@ -12,7 +12,7 @@ pub mod utilities {
   UserKnownHostsFile /dev/null
   StrictHostKeyChecking no
   PasswordAuthentication no
-  IdentityFile /Users/me/.vagrant/machines/default/qemu/private_key
+  IdentityFile /path/to/private_key
   IdentitiesOnly yes
   LogLevel FATAL
   PubkeyAcceptedKeyTypes +ssh-rsa
@@ -26,7 +26,7 @@ pub mod utilities {
       ansible_host: 127.0.0.1
       ansible_port: 50022
       ansible_user: vagrant
-      ansible_ssh_private_key_file: /Users/me/.vagrant/machines/default/qemu/private_key
+      ansible_ssh_private_key_file: /path/to/private_key
 "###
         )
     }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,2 +1,3 @@
 pub mod ansible;
 pub mod parser;
+pub mod ssh_config;

--- a/src/core/parser.rs
+++ b/src/core/parser.rs
@@ -1,6 +1,6 @@
 use crate::common::error::AppError;
-use crate::core::ansible::{HostParams, Hosts, Inventory};
-use ssh2_config::{Host, ParseRule, SshConfig};
+use crate::core::ansible::Inventory;
+use crate::core::ssh_config::SshConfig;
 use std::io::{BufRead, Write};
 use tracing::info;
 
@@ -12,56 +12,21 @@ pub fn parse_and_serialise_as_yaml(
     input: &mut impl BufRead,
     output: &mut impl Write,
 ) -> Result<(), AppError> {
-    let hosts = parse(input)?;
-    info!("Successfully parsed SSH config: {:?}", hosts);
-    let inventory = Inventory::new(environment, hosts);
+    let ssh_configs = SshConfig::parse(input)?;
+    info!("Successfully parsed SSH config: {:?}", ssh_configs);
+    let inventory = Inventory::new(environment, &ssh_configs);
     info!("Successfully generated inventory: {:?}", inventory);
     serde_yaml::to_writer(output, &inventory)?;
     info!("Successfully serialised inventory as YAML",);
     Ok(())
 }
 
-/// Parse the provided SSH config into a collection of `Hosts`.
-pub fn parse(reader: &mut impl BufRead) -> Result<Hosts, AppError> {
-    let config = SshConfig::default().parse(reader, ParseRule::STRICT)?;
-    let ssh_hosts: Vec<&Host> = ssh_hosts_from(&config);
-    let hosts = ssh_hosts
-        .into_iter()
-        .map(|host| (host_nickname(&host.pattern), HostParams::new(&host.params)))
-        .collect::<Hosts>();
-    Ok(hosts)
-}
-
-/// Get actual hosts from the provided SSH config,
-/// i.e. remove wildcard ('*') host.
-fn ssh_hosts_from(config: &SshConfig) -> Vec<&Host> {
-    config
-        .get_hosts()
-        .iter()
-        .filter(|host| {
-            host.pattern
-                .iter()
-                .any(|host_clause| host_clause.pattern != "*")
-        })
-        .collect::<Vec<&Host>>()
-}
-
-fn host_nickname(pattern: &[ssh2_config::HostClause]) -> String {
-    pattern
-        .first()
-        .expect("host pattern to contains at a least 1 host nickname")
-        .pattern
-        .to_owned()
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{parse, parse_and_serialise_as_yaml};
+    use super::parse_and_serialise_as_yaml;
     use crate::common::error::AppError;
     use crate::common::testing::utilities::{sample_ansible_inventory, SAMPLE_SSH_CONFIG};
-    use crate::core::ansible::HostParams;
     use std::io::BufWriter;
-    use std::path::PathBuf;
 
     #[test]
     fn parse_ssh_config_and_serialise_as_yaml() -> Result<(), AppError> {
@@ -78,35 +43,6 @@ mod tests {
         let yaml = String::from_utf8(bytes.to_vec())?;
 
         assert_eq!(yaml, sample_ansible_inventory(environment));
-        Ok(())
-    }
-
-    #[test]
-    fn parse_ssh_config() -> Result<(), AppError> {
-        // Given:
-        let mut input = SAMPLE_SSH_CONFIG.as_bytes();
-
-        // When:
-        let hosts = parse(&mut input)?;
-
-        // Then:
-        assert_eq!(hosts.len(), 1);
-        assert!(hosts.contains_key("default"));
-        let host_params = hosts
-            .get("default")
-            .cloned()
-            .expect("value to exist since key exists");
-        assert_eq!(
-            host_params,
-            HostParams {
-                ansible_host: Some("127.0.0.1".to_string()),
-                ansible_port: Some(50022u16),
-                ansible_user: Some("vagrant".to_string()),
-                ansible_ssh_private_key_file: Some(PathBuf::from("/path/to/private_key")),
-                ansible_ssh_common_args: None, // Not supported for now.
-                ansible_ssh_extra_args: None,  // Not supported for now.
-            }
-        );
         Ok(())
     }
 }

--- a/src/core/parser.rs
+++ b/src/core/parser.rs
@@ -102,9 +102,7 @@ mod tests {
                 ansible_host: Some("127.0.0.1".to_string()),
                 ansible_port: Some(50022u16),
                 ansible_user: Some("vagrant".to_string()),
-                ansible_ssh_private_key_file: Some(PathBuf::from(
-                    "/Users/me/.vagrant/machines/default/qemu/private_key"
-                )),
+                ansible_ssh_private_key_file: Some(PathBuf::from("/path/to/private_key")),
                 ansible_ssh_common_args: None, // Not supported for now.
                 ansible_ssh_extra_args: None,  // Not supported for now.
             }

--- a/src/core/ssh_config.rs
+++ b/src/core/ssh_config.rs
@@ -1,0 +1,421 @@
+use std::collections::{BTreeMap, HashMap};
+use std::hash::Hash;
+use std::io::BufRead;
+use strum::IntoEnumIterator;
+use strum_macros::{Display, EnumIter};
+use tracing::warn;
+
+/// Field list all the possible keys for a SSH configuration.
+/// See also: http://man.openbsd.org/OpenBSD-current/man5/ssh_config.5
+#[derive(Clone, Copy, Debug, Display, EnumIter, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum Field {
+    Host,
+    Match,
+    AddKeysToAgent,
+    AddressFamily,
+    BatchMode,
+    BindAddress,
+    BindInterface,
+    CanonicalDomains,
+    CanonicalizeFallbackLocal,
+    CanonicalizeFallbackLock,
+    CanonicalizeHostname,
+    CanonicalizeMaxDots,
+    CanonicalizePermittedCNAMEs,
+    CASignatureAlgorithms,
+    CertificateFile,
+    ChannelTimeout,
+    CheckHostIP,
+    Ciphers,
+    ClearAllForwardings,
+    Compression,
+    ConnectionAttempts,
+    ConnectTimeout,
+    ControlMaster,
+    ControlPath,
+    ControlPersist,
+    DynamicForward,
+    EnableEscapeCommandline,
+    EnableSSHKeysign,
+    EscapeChar,
+    ExitOnForwardFailure,
+    FingerprintHash,
+    ForkAfterAuthentication,
+    ForwardAgent,
+    ForwardX11,
+    ForwardX11Timeout,
+    ForwardX11Trusted,
+    GatewayPorts,
+    GlobalKnownHostsFile,
+    GSSAPIAuthentication,
+    GSSAPIDelegateCredentials,
+    HashKnownHosts,
+    HostbasedAcceptedAlgorithms,
+    HostbasedAuthentication,
+    HostbasedKeyTypes,
+    HostKeyAlgorithms,
+    HostKeyAlias,
+    HostName,
+    IdentitiesOnly,
+    IdentityAgent,
+    IdentityFile,
+    IgnoreUnknown,
+    Include,
+    IPQoS,
+    KbdInteractiveAuthentication,
+    KbdInteractiveDevices,
+    KexAlgorithms,
+    KnownHostsCommand,
+    LocalCommand,
+    LocalForward,
+    LogLevel,
+    LogVerbose,
+    Mac,
+    MACs,
+    NoHostAuthenticationForLocalhost,
+    NumberOfPasswordPrompts,
+    ObscureKeystrokeTiming,
+    PasswordAuthentication,
+    PermitLocalCommand,
+    PermitRemoteOpen,
+    PKCS11Provider,
+    Port,
+    PreferredAuthentications,
+    ProxyCommand,
+    ProxyJump,
+    ProxyUseFdpass,
+    PubkeyAcceptedAlgorithms,
+    PubkeyAcceptedKeyTypes,
+    PubkeyAuthentication,
+    RekeyLimit,
+    RemoteCommand,
+    RemoteForward,
+    RequestTTY,
+    RequiredRSASize,
+    RevokedHostKeys,
+    SecurityKeyProvider,
+    SendEnv,
+    ServerAliveCountMax,
+    ServerAliveInterval,
+    SessionType,
+    SetEnv,
+    StdinNull,
+    StreamLocalBindMask,
+    StreamLocalBindUnlink,
+    StrictHostKeyChecking,
+    SyslogFacility,
+    Tag,
+    TCPKeepAlive,
+    Tunnel,
+    TunnelDevice,
+    UpdateHostKeys,
+    UseKeychain,
+    User,
+    UserKnownHostsFile,
+    VerifyHostKeyDNS,
+    VisualHostKey,
+    XAuthLocation,
+}
+
+lazy_static! {
+    #[derive(Debug)]
+    static ref FIELDS: HashMap<String, Field> = Field::iter()
+        .map(|field| (field.to_string().to_lowercase(), field)) // SSH config keys are case-insensitive.
+        .collect::<HashMap<String, Field>>();
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SshConfig {
+    pub host: String,
+    pub fields: BTreeMap<Field, String>,
+}
+
+impl SshConfig {
+    pub fn new() -> SshConfig {
+        SshConfig {
+            host: "*".to_string(),
+            fields: BTreeMap::new(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.fields.is_empty()
+    }
+}
+
+impl SshConfig {
+    pub fn parse(reader: &mut impl BufRead) -> Result<Vec<SshConfig>, std::io::Error> {
+        let mut ssh_configs = Vec::new(); // There can me more than one SSH config in a SSH config file.
+        let mut ssh_config = SshConfig::new();
+
+        let mut line = String::new(); // Reuse the same memory for each line to reduce allocations.
+        loop {
+            line.clear();
+            if reader.read_line(&mut line)? == 0 {
+                if !ssh_config.is_empty() {
+                    ssh_configs.push(ssh_config);
+                }
+                break;
+            }
+            let line = line.trim(); // Remove leading and trailing whitespaces.
+            if line.is_empty() {
+                continue; // Skip empty lines.
+            }
+            if line.starts_with('#') {
+                continue; // Skip comments.
+            }
+            if let Some((key, value)) = line.split_once(' ') {
+                let case_insensitive_key = key.to_lowercase(); // SSH config keys are case-insensitive.
+                let value = value.trim();
+                if let Some(&field) = FIELDS.get(&case_insensitive_key) {
+                    // Known SSH config field:
+                    if field == Field::Host {
+                        if !ssh_config.is_empty() {
+                            // Assume the beginning of a new SSH config, and add the SSH config being processed so far to our list of SSH configs:
+                            ssh_configs.push(ssh_config);
+                            // And re-initialise the current SSH config:
+                            ssh_config = SshConfig::new();
+                        }
+                        ssh_config.host = value.to_owned();
+                    } else if let Some(old_value) =
+                        ssh_config.fields.insert(field, value.to_owned())
+                    {
+                        warn!(
+                            key,
+                            old_value,
+                            new_value = value,
+                            "Overwrote previous value in SSH config",
+                        );
+                    }
+                } else {
+                    warn!(line, "Invalid SSH config: unknown field: {}", key);
+                }
+            } else {
+                warn!(line, "Invalid SSH config: line is not well-formed");
+            }
+        }
+        Ok(ssh_configs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Field, SshConfig};
+    use crate::common::testing::utilities::SAMPLE_SSH_CONFIG;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn parse_ssh_config() -> Result<(), std::io::Error> {
+        // Given:
+        let mut input = SAMPLE_SSH_CONFIG.as_bytes();
+
+        // When:
+        let ssh_configs = SshConfig::parse(&mut input)?;
+
+        // Then:
+        assert_eq!(1, ssh_configs.len());
+        assert_eq!(
+            ssh_configs[0],
+            SshConfig {
+                host: "default".to_string(),
+                fields: BTreeMap::from([
+                    (Field::HostName, "127.0.0.1".to_string()),
+                    (Field::User, "vagrant".to_string()),
+                    (Field::Port, "50022".to_string()),
+                    (Field::UserKnownHostsFile, "/dev/null".to_string()),
+                    (Field::StrictHostKeyChecking, "no".to_string()),
+                    (Field::PasswordAuthentication, "no".to_string()),
+                    (Field::IdentityFile, "/path/to/private_key".to_string()),
+                    (Field::IdentitiesOnly, "yes".to_string()),
+                    (Field::LogLevel, "FATAL".to_string()),
+                    (Field::PubkeyAcceptedKeyTypes, "+ssh-rsa".to_string()),
+                    (Field::HostKeyAlgorithms, "+ssh-rsa".to_string()),
+                ]),
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_empty_string() -> Result<(), std::io::Error> {
+        // Given:
+        let mut input = "".as_bytes();
+
+        // When:
+        let ssh_configs = SshConfig::parse(&mut input)?;
+
+        // Then:
+        assert_eq!(0, ssh_configs.len());
+        Ok(())
+    }
+
+    #[test]
+    fn parse_ssh_config_with_empty_lines() -> Result<(), std::io::Error> {
+        // Given:
+        let mut input = r#"Host default
+
+  HostName 127.0.0.1
+
+"#
+        .as_bytes();
+
+        // When:
+        let ssh_configs = SshConfig::parse(&mut input)?;
+
+        // Then:
+        assert_eq!(1, ssh_configs.len());
+        assert_eq!(
+            ssh_configs[0],
+            SshConfig {
+                host: "default".to_string(),
+                fields: BTreeMap::from([(Field::HostName, "127.0.0.1".to_string()),]),
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_ssh_config_with_comments() -> Result<(), std::io::Error> {
+        // Given:
+        let mut input = r#"Host default
+  # The following line is the hostname:
+  HostName 127.0.0.1
+  # This is the end of the SSH configuration."#
+            .as_bytes();
+
+        // When:
+        let ssh_configs = SshConfig::parse(&mut input)?;
+
+        // Then:
+        assert_eq!(1, ssh_configs.len());
+        assert_eq!(
+            ssh_configs[0],
+            SshConfig {
+                host: "default".to_string(),
+                fields: BTreeMap::from([(Field::HostName, "127.0.0.1".to_string()),]),
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_ssh_config_with_lowercased_keys() -> Result<(), std::io::Error> {
+        // Given:
+        let mut input = "host default\nhostname 127.0.0.1".as_bytes();
+
+        // When:
+        let ssh_configs = SshConfig::parse(&mut input)?;
+
+        // Then:
+        assert_eq!(1, ssh_configs.len());
+        assert_eq!(
+            ssh_configs[0],
+            SshConfig {
+                host: "default".to_string(),
+                fields: BTreeMap::from([(Field::HostName, "127.0.0.1".to_string()),]),
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_ssh_config_with_duplicate_field_keeps_last_value() -> Result<(), std::io::Error> {
+        // Given:
+        let mut input = r#"Host default
+  HostName 127.0.0.1
+  HostName 127.0.0.2"#
+            .as_bytes();
+
+        // When:
+        let ssh_configs = SshConfig::parse(&mut input)?;
+
+        // Then:
+        assert_eq!(1, ssh_configs.len());
+        assert_eq!(
+            ssh_configs[0],
+            SshConfig {
+                host: "default".to_string(),
+                fields: BTreeMap::from([(Field::HostName, "127.0.0.2".to_string()),]),
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_ssh_config_with_unknown_field() -> Result<(), std::io::Error> {
+        // Given:
+        let mut input = r#"Host default
+  Unknown foobar
+  HostName 127.0.0.1"#
+            .as_bytes();
+
+        // When:
+        let ssh_configs = SshConfig::parse(&mut input)?;
+
+        // Then:
+        assert_eq!(1, ssh_configs.len());
+        assert_eq!(
+            ssh_configs[0],
+            SshConfig {
+                host: "default".to_string(),
+                fields: BTreeMap::from([(Field::HostName, "127.0.0.1".to_string()),]),
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_ssh_config_with_non_well_formed_line() -> Result<(), std::io::Error> {
+        // Given:
+        let mut input = r#"Host default
+  invalid-line
+  HostName 127.0.0.1"#
+            .as_bytes();
+
+        // When:
+        let ssh_configs = SshConfig::parse(&mut input)?;
+
+        // Then:
+        assert_eq!(1, ssh_configs.len());
+        assert_eq!(
+            ssh_configs[0],
+            SshConfig {
+                host: "default".to_string(),
+                fields: BTreeMap::from([(Field::HostName, "127.0.0.1".to_string()),]),
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_two_ssh_configs() -> Result<(), std::io::Error> {
+        // Given:
+        let mut input = r#"Host host1
+  HostName 192.168.0.1
+Host host2
+  HostName 192.168.0.2
+"#
+        .as_bytes();
+
+        // When:
+        let ssh_configs = SshConfig::parse(&mut input)?;
+
+        // Then:
+        assert_eq!(2, ssh_configs.len());
+        assert_eq!(
+            ssh_configs[0],
+            SshConfig {
+                host: "host1".to_string(),
+                fields: BTreeMap::from([(Field::HostName, "192.168.0.1".to_string()),]),
+            }
+        );
+        assert_eq!(
+            ssh_configs[1],
+            SshConfig {
+                host: "host2".to_string(),
+                fields: BTreeMap::from([(Field::HostName, "192.168.0.2".to_string()),]),
+            }
+        );
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,9 @@
 mod common;
 mod core;
 
+#[macro_use]
+extern crate lazy_static;
+
 use crate::common::cli;
 use crate::common::error::AppError;
 use crate::core::parser::parse_and_serialise_as_yaml;


### PR DESCRIPTION
### Changelog

#### Main

- Add our own (rather permissive) SSH configuration parser (+tests).
- Add support for `ansible_ssh_extra_args` and `ansible_ssh_common_args` (+tests).

Resolves #4.

#### Misc.

- Improve tests' readability and string literals used in tests.
- `just cover` now builds `s2a` with the necessary flags to have coverage also collected for end-to-end tests.
- Git pre-commit hooks now fix files' BOM. (Previously: just check files' BOM.)

### Manual testing

```console
$ vagrant ssh-config | s2a -e local -o inventories/local.yaml 
$ ansible local -m ping -i inventories/
default | SUCCESS => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python3"
    },
    "changed": false,
    "ping": "pong"
}
```

N.B.: no warning about the authenticity of the host anymore, as `ansible_ssh_extra_args` could now contain, among others, `-o StrictHostKeyChecking=no`.