### PR TITLE
Remove --debug flag and console subscriber

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ lto = true
 [dependencies]
 clap = { version = "4.4.7", features = ["derive", "string"] }
 clap-verbosity-flag = "2.1.0"
-console-subscriber = "0.2.0"
 lazy_static = "1.4.0"
 log = "0.4.20"
 serde = { version = "1.0.192", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -164,8 +164,6 @@ Options:
           More output per occurrence
   -q, --quiet...
           Less output per occurrence
-      --debug
-
   -e, --environment <ENVIRONMENT>
           Name of the environment to generate [default: local]
   -i, --input-filepath <INPUT_FILEPATH>

--- a/src/common/cli.rs
+++ b/src/common/cli.rs
@@ -12,9 +12,6 @@ pub struct Arguments {
     #[clap(flatten)]
     pub verbose: Verbosity<WarnLevel>,
 
-    #[arg(long, default_value_t = false)]
-    pub debug: bool,
-
     /// Name of the environment to generate.
     #[arg(short, long, default_value_t = String::from("local"))]
     pub environment: String,

--- a/src/common/tracing.rs
+++ b/src/common/tracing.rs
@@ -11,16 +11,12 @@ pub fn initialise(args: &Arguments) {
         log::Level::Trace => Level::TRACE,
     };
 
-    if args.debug {
-        console_subscriber::init();
-    } else {
-        let subscriber = FmtSubscriber::builder()
-            .json()
-            .with_max_level(level)
-            .with_thread_ids(true)
-            .finish();
-        tracing::subscriber::set_global_default(subscriber)
-            .expect("setting default subscriber failed");
-    }
+    let subscriber = FmtSubscriber::builder()
+        .json()
+        .with_max_level(level)
+        .with_thread_ids(true)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+
     debug!("Tracing initialised.");
 }


### PR DESCRIPTION
... as it requires:

```
RUSTFLAGS="--cfg tokio_unstable"
```

for it to work, which is not practical for a CLI exposed to users.

Besides, `s2a` does not use `tokio` and the level of concurrency, parallelism, and/or async. I/O does not warrant the usage of such tools.