### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.0](https://github.com/marccarre/ssh-to-ansible/releases/tag/0.3.0) - 2023-11-12
+
+- Added support for `ansible_ssh_extra_args` and `ansible_ssh_common_args` ([#5](https://github.com/marccarre/ssh-to-ansible/pull/5)).
+- Removed the `--debug` CLI flag and the logic behind this flag. ([#6](https://github.com/marccarre/ssh-to-ansible/pull/6)).
+
 ## [0.2.0](https://github.com/marccarre/ssh-to-ansible/releases/tag/0.2.0) - 2023-11-11
 
 - Added the ability to read SSH configuration from either `stdin` (default) or

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-to-ansible"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Marc Carré <carre.marc@gmail.com>"]
 categories = ["command-line-utilities", "development-tools", "parsing"]
 description = "A tool to convert a SSH configuration to an Ansible YAML inventory."


### PR DESCRIPTION
### Changelog

- Added support for `ansible_ssh_extra_args` and `ansible_ssh_common_args` ([#5](https://github.com/marccarre/ssh-to-ansible/pull/5)).
- Removed the `--debug` CLI flag and the logic behind this flag. ([#6](https://github.com/marccarre/ssh-to-ansible/pull/6)).