### PR TITLE
Add support for ansible vars

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,10 @@ lto = true
 [dependencies]
 clap = { version = "4.5.17", features = ["derive", "string"] }
 clap-verbosity-flag = "2.2.1"
+derive_more = { version = "1.0.0", features = ["display", "from_str"] }
 lazy_static = "1.5.0"
 log = "0.4.22"
+regex = "1.10.6"
 serde = { version = "1.0.210", features = ["derive"] }
 serde_yaml = "0.9.33"
 strum = { version = "0.25.0", features = ["derive"] }
@@ -42,4 +44,5 @@ tracing-subscriber = { version = "0.3.18", features = ["json"] }
 [dev-dependencies]
 assert_cmd = "2.0.16"
 predicates = "3.1.2"
+rstest = "0.22.0"
 tempfile = "3.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,19 +27,19 @@ lto = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.4.7", features = ["derive", "string"] }
-clap-verbosity-flag = "2.1.0"
-lazy_static = "1.4.0"
-log = "0.4.20"
-serde = { version = "1.0.192", features = ["derive"] }
-serde_yaml = "0.9.27"
+clap = { version = "4.5.17", features = ["derive", "string"] }
+clap-verbosity-flag = "2.2.1"
+lazy_static = "1.5.0"
+log = "0.4.22"
+serde = { version = "1.0.210", features = ["derive"] }
+serde_yaml = "0.9.33"
 strum = { version = "0.25.0", features = ["derive"] }
-strum_macros = "0.25.3"
-thiserror = "1.0.50"
+strum_macros = "0.26.3"
+thiserror = "1.0.63"
 tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.17", features = ["json"] }
+tracing-subscriber = { version = "0.3.18", features = ["json"] }
 
 [dev-dependencies]
-assert_cmd = "2.0.12"
-predicates = "3.0.4"
-tempfile = "3.8.1"
+assert_cmd = "2.0.16"
+predicates = "3.1.2"
+tempfile = "3.12.0"

--- a/README.md
+++ b/README.md
@@ -103,6 +103,43 @@ dev:
 ```
 <!-- markdownlint-enable MD013 -->
 
+#### Configure `vars` in the Ansible inventory
+
+Provide colon-separated `key:value` pairs using the `--var` CLI option:
+
+<!-- markdownlint-disable MD013 -->
+```console
+$ cat <<EOF | ./s2a --var become:true --var http_port:"'8080'" --var num_workers:4 --var user:root
+Host default
+  HostName 127.0.0.1
+  User vagrant
+  Port 50022
+  UserKnownHostsFile /dev/null
+  StrictHostKeyChecking no
+  PasswordAuthentication no
+  IdentityFile /Users/me/.vagrant/machines/default/qemu/private_key
+  IdentitiesOnly yes
+  LogLevel FATAL
+  PubkeyAcceptedKeyTypes +ssh-rsa
+  HostKeyAlgorithms +ssh-rsa
+EOF
+
+local:
+  hosts:
+    default:
+      ansible_host: 127.0.0.1
+      ansible_port: 50022
+      ansible_user: vagrant
+      ansible_ssh_private_key_file: /Users/me/.vagrant/machines/default/qemu/private_key
+      ansible_ssh_extra_args: -o HostKeyAlgorithms=+ssh-rsa -o IdentitiesOnly=yes -o LogLevel=FATAL -o PasswordAuthentication=no -o PubkeyAcceptedKeyTypes=+ssh-rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+  vars:
+    become: true
+    http_port: '8080'
+    num_workers: 4
+    user: root
+```
+<!-- markdownlint-enable MD013 -->
+
 #### Read from input file instead of `stdin`
 
 <!-- markdownlint-disable MD013 -->
@@ -177,11 +214,13 @@ Usage: s2a [OPTIONS]
 
 Options:
   -v, --verbose...
-          More output per occurrence
+          Increase logging verbosity
   -q, --quiet...
-          Less output per occurrence
+          Decrease logging verbosity
   -e, --environment <ENVIRONMENT>
           Name of the environment to generate [default: local]
+      --var <VARS>
+          Ansible variables to add to the hosts, as colon-separated name:value pair, e.g., --var new_ssh_port:22222 --var swap_size:3G
   -i, --input-filepath <INPUT_FILEPATH>
           Path of the input SSH configuration to parse [default: stdin]
   -o, --output-filepath <OUTPUT_FILEPATH>

--- a/src/common/cli.rs
+++ b/src/common/cli.rs
@@ -130,7 +130,7 @@ mod tests {
             "--var",
             "num_workers:4",
             "--var",
-            "pi:3.14",
+            "pi:1.23",
             "--var",
             "swap_size:3G",
             "--var",
@@ -141,7 +141,7 @@ mod tests {
         let vars = args.vars.unwrap();
         assert_eq!(vars.len(), 5);
 
-        let (key1, value1) = vars.clone().into_iter().nth(0).unwrap();
+        let (key1, value1) = vars.clone().into_iter().next().unwrap();
         assert_eq!(key1, "become");
         assert_eq!(value1, ValueType::Bool(true));
 
@@ -151,7 +151,7 @@ mod tests {
 
         let (key3, value3) = vars.clone().into_iter().nth(2).unwrap();
         assert_eq!(key3, "pi");
-        assert_eq!(value3, ValueType::Float64(3.14));
+        assert_eq!(value3, ValueType::Float64(1.23));
 
         let (key4, value4) = vars.clone().into_iter().nth(3).unwrap();
         assert_eq!(key4, "swap_size");

--- a/src/common/testing.rs
+++ b/src/common/testing.rs
@@ -32,6 +32,25 @@ pub mod utilities {
         )
     }
 
+    pub fn sample_ansible_inventory_with_vars(environment: &str) -> String {
+        format!(
+            r#"{environment}:
+  hosts:
+    default:
+      ansible_host: 127.0.0.1
+      ansible_port: 50022
+      ansible_user: vagrant
+      ansible_ssh_private_key_file: /path/to/private_key
+      ansible_ssh_extra_args: -o HostKeyAlgorithms=+ssh-rsa -o IdentitiesOnly=yes -o LogLevel=FATAL -o PasswordAuthentication=no -o PubkeyAcceptedKeyTypes=+ssh-rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+  vars:
+    become: true
+    http_port: '8080'
+    num_workers: 4
+    swap_size: 3G
+"#
+        )
+    }
+
     pub fn temp_file(filename: &str, content: &str) -> Result<(TempDir, PathBuf), std::io::Error> {
         let (dir, input_filepath) = temp_filepath(filename)?;
         let mut input_file = File::create(&input_filepath)?;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,3 +1,4 @@
 pub mod ansible;
 pub mod parser;
 pub mod ssh_config;
+pub mod variables;

--- a/src/core/parser.rs
+++ b/src/core/parser.rs
@@ -1,6 +1,7 @@
 use crate::common::error::AppError;
 use crate::core::ansible::Inventory;
 use crate::core::ssh_config::SshConfig;
+use crate::core::variables::ValueType;
 use std::io::{BufRead, Write};
 use tracing::info;
 
@@ -9,12 +10,13 @@ use tracing::info;
 /// inventory to the provided output.
 pub fn parse_and_serialise_as_yaml(
     environment: &str,
+    vars: &Option<Vec<(String, ValueType)>>,
     input: &mut impl BufRead,
     output: &mut impl Write,
 ) -> Result<(), AppError> {
     let ssh_configs = SshConfig::parse(input)?;
     info!("Successfully parsed SSH config: {:?}", ssh_configs);
-    let inventory = Inventory::new(environment, &ssh_configs);
+    let inventory = Inventory::new(environment, &ssh_configs, vars);
     info!("Successfully generated inventory: {:?}", inventory);
     serde_yaml::to_writer(output, &inventory)?;
     info!("Successfully serialised inventory as YAML",);
@@ -25,24 +27,54 @@ pub fn parse_and_serialise_as_yaml(
 mod tests {
     use super::parse_and_serialise_as_yaml;
     use crate::common::error::AppError;
-    use crate::common::testing::utilities::{sample_ansible_inventory, SAMPLE_SSH_CONFIG};
+    use crate::common::testing::utilities::{
+        sample_ansible_inventory, sample_ansible_inventory_with_vars, SAMPLE_SSH_CONFIG,
+    };
+    use crate::core::variables::ValueType;
     use std::io::BufWriter;
 
     #[test]
-    fn parse_ssh_config_and_serialise_as_yaml() -> Result<(), AppError> {
+    fn parse_ssh_config_with_no_vars_and_serialise_as_yaml() -> Result<(), AppError> {
         // Given:
         let mut input = SAMPLE_SSH_CONFIG.as_bytes();
         let mut output = BufWriter::new(Vec::new());
         let environment = "unit-test";
 
         // When:
-        parse_and_serialise_as_yaml(environment, &mut input, &mut output)?;
+        parse_and_serialise_as_yaml(environment, &Option::None, &mut input, &mut output)?;
 
         // Then:
         let bytes = output.buffer();
         let yaml = String::from_utf8(bytes.to_vec())?;
 
         assert_eq!(yaml, sample_ansible_inventory(environment));
+        Ok(())
+    }
+
+    #[test]
+    fn parse_ssh_config_with_vars_and_serialise_as_yaml() -> Result<(), AppError> {
+        // Given:
+        let mut input = SAMPLE_SSH_CONFIG.as_bytes();
+        let mut output = BufWriter::new(Vec::new());
+        let environment = "unit-test";
+        let vars = Some(Vec::from([
+            ("become".to_string(), ValueType::Bool(true)),
+            (
+                "http_port".to_string(),
+                ValueType::String("8080".to_string()),
+            ),
+            ("num_workers".to_string(), ValueType::Int64(4)),
+            ("swap_size".to_string(), ValueType::String("3G".to_string())),
+        ]));
+
+        // When:
+        parse_and_serialise_as_yaml(environment, &vars, &mut input, &mut output)?;
+
+        // Then:
+        let bytes = output.buffer();
+        let yaml = String::from_utf8(bytes.to_vec())?;
+
+        assert_eq!(yaml, sample_ansible_inventory_with_vars(environment));
         Ok(())
     }
 }

--- a/src/core/variables.rs
+++ b/src/core/variables.rs
@@ -1,0 +1,102 @@
+use derive_more::Display;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+use thiserror::Error;
+
+lazy_static! {
+    static ref QUOTED_INTEGER: Regex = Regex::new(r#"^['\\""]*(?<integer>\d+)['\\""]*$"#).unwrap();
+}
+
+#[derive(Clone, Debug, Deserialize, Display, PartialEq, Serialize)]
+pub enum ValueType {
+    #[display("{_0}")]
+    #[serde(untagged)]
+    Bool(bool),
+    #[display("{_0}")]
+    #[serde(untagged)]
+    Int64(i64),
+    #[display("{_0}")]
+    #[serde(untagged)]
+    Float64(f64),
+    #[display("{_0}")]
+    #[serde(untagged)]
+    String(String),
+}
+
+#[derive(Debug, Display, Error, PartialEq, Eq)]
+pub struct ParseValueTypeError;
+
+impl FromStr for ValueType {
+    // ParseValueTypeError is never used in practice, as we default to `ValueType::String`.
+    type Err = ParseValueTypeError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if let Ok(parsed_value) = bool::from_str(value) {
+            return Ok(ValueType::Bool(parsed_value));
+        }
+        if let Ok(parsed_value) = i64::from_str(value) {
+            return Ok(ValueType::Int64(parsed_value));
+        }
+        if let Ok(parsed_value) = f64::from_str(value) {
+            return Ok(ValueType::Float64(parsed_value));
+        }
+        if let Some(captures) = QUOTED_INTEGER.captures(value) {
+            if let Some(integer) = captures.name("integer") {
+                return Ok(ValueType::String(integer.as_str().to_string()));
+            }
+        }
+        Ok(ValueType::String(value.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::variables::ValueType;
+    use rstest::rstest;
+    use serde_yaml;
+    use std::str::FromStr;
+
+    use super::ParseValueTypeError;
+
+    #[rstest]
+    // Given:
+    #[case::parse_true("true", ValueType::Bool(true))]
+    #[case::parse_false("false", ValueType::Bool(false))]
+    #[case::parse_zero("0", ValueType::Int64(0))]
+    #[case::parse_one("1", ValueType::Int64(1))]
+    #[case::parse_minus_one("-1", ValueType::Int64(-1))]
+    #[case::parse_pi("3.14", ValueType::Float64(3.14))]
+    #[case::parse_unit("3G", ValueType::String("3G".to_string()))]
+    #[case::parse_user("root", ValueType::String("root".to_string()))]
+    #[case::parse_port_as_single_quoted_str("'22'", ValueType::String("22".to_string()))]
+    #[case::parse_port_as_double_quoted_str(r#""22""#, ValueType::String("22".to_string()))]
+    fn from_str(
+        #[case] input: &str,
+        #[case] expected: ValueType,
+    ) -> Result<(), ParseValueTypeError> {
+        // When:
+        let value = ValueType::from_str(input)?;
+        // Then:
+        assert_eq!(value, expected);
+        Ok(())
+    }
+
+    #[rstest]
+    // Given:
+    #[case::serialize_bool(ValueType::Bool(true), "true")]
+    #[case::serialize_int(ValueType::Int64(1337), "1337")]
+    #[case::serialize_float(ValueType::Float64(3.14), "3.14")]
+    #[case::serialize_str(ValueType::String("foo".to_string()), "foo")]
+    #[case::serialize_int_as_str(ValueType::String("22".to_string()), "'22'")]
+    fn serialize_to_yaml(
+        #[case] input: ValueType,
+        #[case] expected: &str,
+    ) -> Result<(), serde_yaml::Error> {
+        // When:
+        let yaml = serde_yaml::to_string(&input)?;
+        // Then:
+        assert_eq!(yaml.trim(), expected);
+        Ok(())
+    }
+}

--- a/src/core/variables.rs
+++ b/src/core/variables.rs
@@ -66,7 +66,7 @@ mod tests {
     #[case::parse_zero("0", ValueType::Int64(0))]
     #[case::parse_one("1", ValueType::Int64(1))]
     #[case::parse_minus_one("-1", ValueType::Int64(-1))]
-    #[case::parse_pi("3.14", ValueType::Float64(3.14))]
+    #[case::parse_pi("1.23", ValueType::Float64(1.23))]
     #[case::parse_unit("3G", ValueType::String("3G".to_string()))]
     #[case::parse_user("root", ValueType::String("root".to_string()))]
     #[case::parse_port_as_single_quoted_str("'22'", ValueType::String("22".to_string()))]
@@ -86,7 +86,7 @@ mod tests {
     // Given:
     #[case::serialize_bool(ValueType::Bool(true), "true")]
     #[case::serialize_int(ValueType::Int64(1337), "1337")]
-    #[case::serialize_float(ValueType::Float64(3.14), "3.14")]
+    #[case::serialize_float(ValueType::Float64(1.23), "1.23")]
     #[case::serialize_str(ValueType::String("foo".to_string()), "foo")]
     #[case::serialize_int_as_str(ValueType::String("22".to_string()), "'22'")]
     fn serialize_to_yaml(


### PR DESCRIPTION
### Changelog

#### Main

- Add support for optional, repeatable `--var` argument in order to add `vars` in the generated Ansible inventory.

#### Misc.

- Upgraded all dependencies.
- Introduced `rstest` for concise, case-based testing.

### Manual testing

```console
$ vagrant up
$ vagrant ssh-config | s2a -e local -o inventories/local.yaml --var become:true --var swap_size:3G
$ cat > print_vars.yaml <<EOF
- name: Print vars
  hosts: all
  become: "{{ become }}"
  gather_facts: false
  tasks:
    - name: Print vars
      ansible.builtin.debug:
        var: hostvars[inventory_hostname]
EOF
$ ansible-playbook -i inventories/local.yaml print_vars.yaml

PLAY [Print vars] **************************************************************

TASK [Print vars] **************************************************************
ok: [default] => {
    "hostvars[inventory_hostname]": {
        // [...]
        "become": true,
        // [...]
        "swap_size": "3G"
    }
}

PLAY RECAP *********************************************************************
default                    : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```
